### PR TITLE
fix: Correct APIClient usage in handlers (v1.1.1)

### DIFF
--- a/src/bot/handlers/keys.py
+++ b/src/bot/handlers/keys.py
@@ -78,7 +78,7 @@ class KeysHandler:
 
             # Get user keys
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get("/vpn/keys", headers=headers)
+            response = await self.api.get("/vpn/keys", headers=headers)
 
             keys = response if isinstance(response, list) else []
 
@@ -139,7 +139,7 @@ class KeysHandler:
 
         try:
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get("/vpn/keys", headers=headers)
+            response = await self.api.get("/vpn/keys", headers=headers)
 
             keys = response if isinstance(response, list) else []
             filtered_keys = [k for k in keys if k.get("key_type", "").lower() == key_type.lower()]
@@ -187,7 +187,7 @@ class KeysHandler:
 
         try:
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get(f"/vpn/keys/{key_id}", headers=headers)
+            response = await self.api.get(f"/vpn/keys/{key_id}", headers=headers)
 
             key = response
             status = "Activa" if key.get("status", "active") == "active" else "Inactiva"
@@ -323,7 +323,7 @@ class KeysHandler:
 
             # Update key
             headers = await self._get_auth_headers(telegram_id)
-            await self.api.api_client.put(
+            await self.api.put(
                 f"/vpn/keys/{key_id}",
                 headers=headers,
                 json={"name": new_name},
@@ -409,7 +409,7 @@ class KeysHandler:
         try:
             # Delete key
             headers = await self._get_auth_headers(telegram_id)
-            await self.api.api_client.delete(f"/vpn/keys/{key_id}", headers=headers)
+            await self.api.delete(f"/vpn/keys/{key_id}", headers=headers)
 
             message = KeysMessages.Actions.KEY_DELETED
 
@@ -455,7 +455,7 @@ class KeysHandler:
 
         try:
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get(
+            response = await self.api.get(
                 f"/vpn/keys/{key_id}/config", headers=headers
             )
 
@@ -512,7 +512,7 @@ class KeysHandler:
 
         try:
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get(
+            response = await self.api.get(
                 f"/vpn/keys/{key_id}/config", headers=headers
             )
 
@@ -565,7 +565,7 @@ class KeysHandler:
 
         try:
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get("/vpn/keys", headers=headers)
+            response = await self.api.get("/vpn/keys", headers=headers)
 
             keys = response if isinstance(response, list) else []
 

--- a/src/bot/handlers/operations.py
+++ b/src/bot/handlers/operations.py
@@ -76,7 +76,7 @@ class OperationsHandler:
             credits = 0
             try:
                 headers = await self._get_auth_headers(telegram_id)
-                response = await self.api.api_client.get(
+                response = await self.api.get(
                     "/referrals/me",
                     headers=headers
                 )
@@ -138,7 +138,7 @@ class OperationsHandler:
             credits = 0
             try:
                 headers = await self._get_auth_headers(telegram_id)
-                response = await self.api.api_client.get(
+                response = await self.api.get(
                     "/referrals/me",
                     headers=headers
                 )
@@ -215,7 +215,7 @@ class OperationsHandler:
                     except ValueError:
                         page = 0
 
-                response = await self.api.api_client.get(
+                response = await self.api.get(
                     f"/transactions?limit=10&offset={page * 10}",
                     headers=headers
                 )
@@ -272,7 +272,7 @@ class OperationsHandler:
 
             try:
                 headers = await self._get_auth_headers(telegram_id)
-                response = await self.api.api_client.get(
+                response = await self.api.get(
                     "/referrals/me",
                     headers=headers
                 )

--- a/src/bot/handlers/referrals.py
+++ b/src/bot/handlers/referrals.py
@@ -80,7 +80,7 @@ class ReferralsHandler:
 
             # Get referral stats
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get(
+            response = await self.api.get(
                 "/referrals/me",
                 headers=headers,
             )
@@ -128,7 +128,7 @@ class ReferralsHandler:
 
             # Get referral stats
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.get(
+            response = await self.api.get(
                 "/referrals/me",
                 headers=headers,
             )
@@ -182,7 +182,7 @@ class ReferralsHandler:
 
             # Redeem credits
             headers = await self._get_auth_headers(telegram_id)
-            response = await self.api.api_client.post(
+            response = await self.api.post(
                 "/referrals/redeem",
                 headers=headers,
                 json={"credits": credits},


### PR DESCRIPTION
## Summary

Fixes critical bug where handlers were calling `self.api.api_client.get()` but APIClient class doesn't have an `api_client` attribute.

### Root Cause
- APIClient class has direct methods: `get()`, `post()`, `put()`, `delete()`
- Code incorrectly assumed wrapper attribute `api_client` exists
- Error: `'APIClient' object has no attribute 'api_client'`

### Changes
- **src/bot/handlers/keys.py** - 8 occurrences fixed
- **src/bot/handlers/operations.py** - 4 occurrences fixed
- **src/bot/handlers/referrals.py** - 3 occurrences fixed

### Impact
✅ VPN keys menu display
✅ Key details and operations (create, delete, rename)
✅ WireGuard config download
✅ Outline link retrieval
✅ Referrals and credits display
✅ Transactions history

### Quality Gates
- ✅ All occurrences replaced (15 total)
- ✅ No remaining `self.api.api_client.*` patterns
- ✅ Consistent with other handlers (payments, subscriptions, consumption)
- ✅ Code review pending

### Testing
Manual testing required:
- `/keys` - Show VPN keys menu
- `/operaciones` - Operations menu
- View key details
- Download WireGuard config
- Get Outline link
- `/referidos` - Referrals stats