### PR TITLE
feat: add referral link to stats message template (#29)

### DIFF
--- a/src/bot/keyboards/messages_referrals.py
+++ b/src/bot/keyboards/messages_referrals.py
@@ -13,11 +13,12 @@ class ReferralsMessages:
             "• Código: `{referral_code}`\n"
             "• Total referidos: `{total_referrals}`\n"
             "• Créditos disponibles: `{referral_credits}`\n\n"
+            "🔗 *Tu enlace:*\n"
+            "{referral_link}\n\n"
             "💡 *Beneficios:*\n"
-            "• Gana 1 crédito por cada amigo referido\n"
-            "• 10 créditos = 1 GB de datos\n"
-            "• Canjea tus créditos cuando quieras\n\n"
-            "Usa /invitar para obtener tu link de invitación"
+            "• 1 crédito por cada amigo invitado\n"
+            "• 5 créditos si tu amigo compra un paquete\n\n"
+            "Comparte tu enlace y gana créditos!"
         )
 
         INVITE_LINK = (

--- a/tests/bot/test_referrals_messages.py
+++ b/tests/bot/test_referrals_messages.py
@@ -28,6 +28,7 @@ class TestReferralsMessages:
         assert "{referral_code}" in ReferralsMessages.Menu.REFERRAL_STATS
         assert "{total_referrals}" in ReferralsMessages.Menu.REFERRAL_STATS
         assert "{referral_credits}" in ReferralsMessages.Menu.REFERRAL_STATS
+        assert "{referral_link}" in ReferralsMessages.Menu.REFERRAL_STATS
 
     @pytest.mark.asyncio
     async def test_invite_link_has_correct_placeholders(self):


### PR DESCRIPTION
## Summary

Update REFERRAL_STATS message template to include the referral link directly in the message.

## Changes

- Add `{referral_link}` placeholder to REFERRAL_STATS message
- Update benefits text to match new referral program structure  
- Add test to verify referral_link placeholder exists

## Related Issue

Closes #29

## Plan

docs/plans/2026-04-04-referral-share-button-plan.md