### PR TITLE
feat: pass referral link to message and keyboard in handler (#31)

### DIFF
--- a/src/bot/handlers/referrals.py
+++ b/src/bot/handlers/referrals.py
@@ -85,18 +85,23 @@ class ReferralsHandler:
                 headers=headers,
             )
 
+            # Build referral link
+            referral_code = response["referral_code"]
+            referral_link = f"https://t.me/usipipobot?start={referral_code}"
+
             # Format message
             message = ReferralsMessages.Menu.REFERRAL_STATS.format(
-                referral_code=response["referral_code"],
+                referral_code=referral_code,
                 total_referrals=response["total_referrals"],
                 referral_credits=response["referral_credits"],
+                referral_link=referral_link,
             )
 
             # Send with keyboard
             if update.message:
                 await update.message.reply_text(
                     text=message,
-                    reply_markup=ReferralsKeyboard.menu(),
+                    reply_markup=ReferralsKeyboard.menu(referral_link),
                     parse_mode="Markdown",
                 )
 

--- a/tests/bot/test_referrals_handlers.py
+++ b/tests/bot/test_referrals_handlers.py
@@ -235,9 +235,13 @@ class TestShowReferralsCommand:
         call_args = mock_update.message.reply_text.call_args
         assert "🎯 *Tu Programa de Referidos*" in call_args[1]["text"]
         assert "ABC123" in call_args[1]["text"]
+        assert "https://t.me/usipipobot?start=ABC123" in call_args[1]["text"]
         assert call_args[1]["parse_mode"] == "Markdown"
-        # Verify keyboard was included
+        # Verify keyboard was included with referral link
         assert call_args[1]["reply_markup"] is not None
+        # Verify keyboard has share button with URL
+        keyboard = call_args[1]["reply_markup"]
+        assert keyboard.inline_keyboard[0][0].url == "https://t.me/usipipobot?start=ABC123"
 
 
 class TestGetReferralLinkCommand:


### PR DESCRIPTION
## Summary

Update show_referrals() handler to build referral link and pass to both message template and keyboard.

## Changes

- Build referral link from API response in show_referrals()
- Pass referral_link to REFERRAL_STATS message template
- Pass referral_link to ReferralsKeyboard.menu() for share button
- Update test to verify referral_link in message and keyboard

## Related Issue

Closes #31

## Plan

docs/plans/2026-04-04-referral-share-button-plan.md