### PR TITLE
fix: use referral_code from backend in operations menu

### DIFF
--- a/src/bot/handlers/operations.py
+++ b/src/bot/handlers/operations.py
@@ -250,13 +250,16 @@ class OperationsHandler:
             # Get referral stats from backend
             invited = 0
             credits = 0
-            link = f"https://t.me/usipipobot?start={telegram_id}"
+            referral_code = str(telegram_id)  # Fallback to telegram_id
+            link = f"https://t.me/usipipobot?start={referral_code}"
 
             try:
                 headers = await self._get_auth_headers(telegram_id)
                 response = await self.api.get("/referrals/me", headers=headers)
                 invited = response.get("total_referrals", 0)
                 credits = response.get("referral_credits", 0)
+                referral_code = response.get("referral_code", referral_code)
+                link = f"https://t.me/usipipobot?start={referral_code}"
             except Exception:
                 # Referrals endpoint may not be implemented yet
                 pass


### PR DESCRIPTION
## Bug Fixed

The `show_referrals` method in operations.py was building the referral link using `telegram_id` instead of the actual `referral_code` from the backend API response.

## Changes

- Extract `referral_code` from `/referrals/me` response
- Build link using backend's `referral_code`
- Fallback to `telegram_id` only if backend doesn't provide code

## Impact

Fixes incorrect referral links displayed when users click the "👥 Referidos" button in the operations menu.

## Verification

- ✅ All 381 unit/bot tests pass
- ✅ All 36 referral-specific tests pass
- ✅ Ruff linting passes