### PR TITLE
fix: resolve referral Markdown errors and add missing handlers

### DIFF
--- a/src/bot/handlers/operations.py
+++ b/src/bot/handlers/operations.py
@@ -14,6 +14,13 @@ from src.infrastructure.token_storage import TokenStorage
 logger = logging.getLogger(__name__)
 
 
+def _escape_md(text: str) -> str:
+    """Escape special Markdown characters in text."""
+    for char in ["_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"]:
+        text = text.replace(char, f"\\{char}")
+    return text
+
+
 class OperationsHandler:
     """Handler para operaciones del usuario."""
 
@@ -264,8 +271,11 @@ class OperationsHandler:
                 # Referrals endpoint may not be implemented yet
                 pass
 
+            # Escape link for Markdown
+            link_escaped = _escape_md(link)
+
             message = OperationsMessages.Referrals.MENU.format(
-                link=link, invited=invited, credits=credits
+                link=link_escaped, invited=invited, credits=credits
             )
             keyboard = OperationsKeyboard.back_to_operations()
 

--- a/src/bot/handlers/referrals.py
+++ b/src/bot/handlers/referrals.py
@@ -14,6 +14,13 @@ from src.infrastructure.token_storage import TokenStorage
 logger = logging.getLogger(__name__)
 
 
+def _escape_md(text: str) -> str:
+    """Escape special Markdown characters in text."""
+    for char in ["_", "*", "[", "]", "(", ")", "~", "`", ">", "#", "+", "-", "=", "|", "{", "}", ".", "!"]:
+        text = text.replace(char, f"\\{char}")
+    return text
+
+
 class ReferralsHandler:
     """Handler for referral system."""
 
@@ -88,13 +95,15 @@ class ReferralsHandler:
             # Build referral link
             referral_code = response["referral_code"]
             referral_link = f"https://t.me/usipipobot?start={referral_code}"
+            # Escape for Markdown (URLs may contain underscores)
+            referral_link_escaped = _escape_md(referral_link)
 
             # Format message
             message = ReferralsMessages.Menu.REFERRAL_STATS.format(
                 referral_code=referral_code,
                 total_referrals=response["total_referrals"],
                 referral_credits=response["referral_credits"],
-                referral_link=referral_link,
+                referral_link=referral_link_escaped,
             )
 
             # Send with keyboard
@@ -141,10 +150,12 @@ class ReferralsHandler:
             # Build referral link
             referral_code = response["referral_code"]
             referral_link = f"https://t.me/usipipobot?start={referral_code}"
+            # Escape for Markdown (URLs may contain underscores)
+            referral_link_escaped = _escape_md(referral_link)
 
             # Format message
             message = ReferralsMessages.Menu.INVITE_LINK.format(
-                referral_link=referral_link,
+                referral_link=referral_link_escaped,
             )
 
             # Send message
@@ -161,6 +172,65 @@ class ReferralsHandler:
                     ReferralsMessages.Error.SYSTEM_ERROR,
                     parse_mode="Markdown",
                 )
+
+    async def redeem_credits(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Show redeem credits confirmation keyboard."""
+        if update.effective_user is None or update.callback_query is None:
+            return
+
+        telegram_id = update.effective_user.id
+        query = update.callback_query
+        logger.info(f"🎯 User {telegram_id} opening redeem credits")
+
+        try:
+            # Check authentication
+            if not await self.tokens.is_authenticated(telegram_id):
+                await self._safe_answer_query(query)
+                await query.edit_message_text(
+                    text=ReferralsMessages.Error.NOT_AUTHENTICATED,
+                    parse_mode="Markdown",
+                )
+                return
+
+            # Get current credits
+            headers = await self._get_auth_headers(telegram_id)
+            response = await self.api.get("/referrals/me", headers=headers)
+            credits = response.get("referral_credits", 0)
+
+            if credits <= 0:
+                await self._safe_answer_query(query)
+                await query.edit_message_text(
+                    text=ReferralsMessages.Error.INSUFFICIENT_CREDITS,
+                    parse_mode="Markdown",
+                )
+                return
+
+            message = f"💰 *Canjear Créditos*\n\nTienes `{credits}` créditos disponibles.\n\n10 créditos = 1 GB de datos\n\n¿Cuántos créditos deseas canjear?"
+
+            await self._safe_answer_query(query)
+            await self._safe_edit_message(
+                query=query,
+                context=context,
+                text=message,
+                reply_markup=ReferralsKeyboard.redeem_confirmation(credits),
+            )
+
+        except Exception as e:
+            logger.error(f"Error opening redeem credits: {e}")
+            await self._safe_answer_query(query)
+            await query.edit_message_text(
+                text=ReferralsMessages.Error.SYSTEM_ERROR,
+                parse_mode="Markdown",
+            )
+
+    async def cancel_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Handle cancel callback."""
+        if update.effective_user is None or update.callback_query is None:
+            return
+
+        query = update.callback_query
+        await self._safe_answer_query(query)
+        await self.show_referrals(update, context)
 
     async def redeem_credits_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Handle redeem credits callback."""
@@ -281,8 +351,16 @@ def get_referrals_callback_handlers(api_client: APIClient, token_storage: TokenS
 
     return [
         CallbackQueryHandler(
+            handler.redeem_credits,
+            pattern=r"^referral_redeem$",
+        ),
+        CallbackQueryHandler(
             handler.redeem_credits_callback,
             pattern=r"^referral_redeem_confirm:\d+$",
+        ),
+        CallbackQueryHandler(
+            handler.cancel_callback,
+            pattern=r"^referral_cancel$",
         ),
         CallbackQueryHandler(
             handler.apply_code_callback,

--- a/tests/bot/test_referrals_handlers.py
+++ b/tests/bot/test_referrals_handlers.py
@@ -235,11 +235,12 @@ class TestShowReferralsCommand:
         call_args = mock_update.message.reply_text.call_args
         assert "🎯 *Tu Programa de Referidos*" in call_args[1]["text"]
         assert "ABC123" in call_args[1]["text"]
-        assert "https://t.me/usipipobot?start=ABC123" in call_args[1]["text"]
+        # URL is escaped for Markdown (dots and = escaped)
+        assert "https://t\\.me/usipipobot?start\\=ABC123" in call_args[1]["text"]
         assert call_args[1]["parse_mode"] == "Markdown"
         # Verify keyboard was included with referral link
         assert call_args[1]["reply_markup"] is not None
-        # Verify keyboard has share button with URL
+        # Verify keyboard has share button with URL (unescaped in keyboard)
         keyboard = call_args[1]["reply_markup"]
         assert keyboard.inline_keyboard[0][0].url == "https://t.me/usipipobot?start=ABC123"
 
@@ -291,7 +292,8 @@ class TestGetReferralLinkCommand:
         mock_update.message.reply_text.assert_called_once()
         call_args = mock_update.message.reply_text.call_args
         assert "🔗 *Tu Link de Invitación*" in call_args[1]["text"]
-        assert "https://t.me/usipipobot?start=ABC123" in call_args[1]["text"]
+        # URL is escaped for Markdown
+        assert "https://t\\.me/usipipobot?start\\=ABC123" in call_args[1]["text"]
         assert call_args[1]["parse_mode"] == "Markdown"
         # No reply_markup for this command
         assert "reply_markup" not in call_args[1]


### PR DESCRIPTION
## Bugs Fixed

### 1. Markdown Parse Error
The `/referidos` command was failing with:
```
Error showing referrals: Can't parse entities: can't find end of the entity starting at byte offset 199
```

**Root cause:** Referral URLs contain underscores (`_`) which Telegram Markdown interprets as italic syntax. URLs like `https://t.me/usipipobot?start=ABC_123` broke parsing.

**Fix:** Escape special Markdown characters (`_`, `.`, `=`, etc.) in URLs before embedding in messages.

### 2. Missing Button Handlers
The referral keyboard had buttons with no handlers:
- `referral_redeem` - No handler to show redeem confirmation
- `referral_cancel` - No handler to cancel and go back

**Fix:** Added `redeem_credits()` and `cancel_callback()` handlers.

### 3. Operations Menu Integration
The operations menu referral display also had the same URL escaping issue.

**Fix:** Applied same URL escaping pattern.

## Changes
- **src/bot/handlers/referrals.py** - Added `_escape_md()`, `redeem_credits()`, `cancel_callback()`, registered new handlers
- **src/bot/handlers/operations.py** - Added `_escape_md()`, applied to referral link
- **tests/bot/test_referrals_handlers.py** - Updated assertions for escaped URLs

## Verification
- ✅ 381 unit/bot tests passing
- ✅ 36 referral tests passing
- ✅ Ruff clean