### PR TITLE
feat: integrate server metrics into show_key_details handler (#52)

### DIFF
--- a/src/bot/handlers/keys.py
+++ b/src/bot/handlers/keys.py
@@ -2,7 +2,7 @@
 
 import io
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -323,7 +323,7 @@ class KeysHandler:
             )
 
     async def show_key_details(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Muestra detalles de una clave específica."""
+        """Muestra detalles de una clave específica con métricas del servidor."""
         query = update.callback_query
         if query is None or query.data is None:
             return
@@ -353,6 +353,43 @@ class KeysHandler:
             # Generate progress bar
             usage_bar = self._generate_progress_bar(usage_percentage)
 
+            # Format last seen
+            last_seen_at = key.get("last_used_at")
+            if isinstance(last_seen_at, str):
+                try:
+                    last_seen_at = datetime.fromisoformat(last_seen_at).replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    last_seen_at = None
+            last_seen_text = self._format_last_seen(last_seen_at)
+
+            # Fetch server metrics
+            server_id = key.get("server_id")
+            server_metrics = None
+            server_status_line = KeysMessages.SERVER_METRICS_UNAVAILABLE
+            server_bandwidth = "N/A"
+            server_uptime = KeysMessages.SERVER_UPTIME_UNKNOWN
+
+            if server_id:
+                server_metrics = await self._fetch_server_metrics(
+                    server_id=server_id,
+                    telegram_id=telegram_id,
+                )
+
+                if server_metrics:
+                    is_online = server_metrics.get("outline_api_reachable", False)
+                    active_keys = server_metrics.get("active_keys_count", 0)
+                    total_bytes = server_metrics.get("total_bytes_transferred", 0)
+
+                    if is_online:
+                        server_status_line = KeysMessages.SERVER_METRICS_ONLINE.format(
+                            active_keys=active_keys
+                        )
+                        server_uptime = KeysMessages.SERVER_UPTIME_GOOD
+                    else:
+                        server_status_line = KeysMessages.SERVER_METRICS_OFFLINE
+
+                    server_bandwidth = self._format_bytes(total_bytes)
+
             message = KeysMessages.KEY_DETAILS.format(
                 name=key.get("name", "Unknown"),
                 type=key.get("key_type", "UNKNOWN").upper(),
@@ -364,6 +401,10 @@ class KeysHandler:
                 status=status,
                 status_icon=status_icon,
                 expires=key.get("expires_at", "N/A")[:10] if key.get("expires_at") else "N/A",
+                last_seen=last_seen_text,
+                server_status_line=server_status_line,
+                server_bandwidth=server_bandwidth,
+                server_uptime=server_uptime,
             )
 
             keyboard = KeysKeyboard.key_actions(

--- a/tests/integration/test_show_key_details_metrics.py
+++ b/tests/integration/test_show_key_details_metrics.py
@@ -1,0 +1,202 @@
+"""Integration tests for show_key_details with server metrics."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.bot.handlers.keys import KeysHandler
+
+
+class TestShowKeyDetailsWithMetrics:
+    """Tests for show_key_details handler with server metrics integration."""
+
+    @pytest.fixture
+    def mock_api_client(self):
+        """Create mock API client."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_token_storage(self):
+        """Create mock token storage."""
+        storage = AsyncMock()
+        storage.get.return_value = {"access_token": "test-token"}
+        storage.is_authenticated.return_value = True
+        return storage
+
+    @pytest.fixture
+    def handler(self, mock_api_client, mock_token_storage):
+        """Create KeysHandler with mocked dependencies."""
+        return KeysHandler(mock_api_client, mock_token_storage)
+
+    @pytest.fixture
+    def mock_update(self):
+        """Create mock update with callback query."""
+        update = MagicMock()
+        update.callback_query = MagicMock()
+        update.callback_query.data = "vpn_key_details_key-123"
+        update.callback_query.answer = AsyncMock()
+        update.callback_query.edit_message_text = AsyncMock()
+        update.effective_user = MagicMock()
+        update.effective_user.id = 12345
+        return update
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create mock context."""
+        return MagicMock()
+
+    async def test_show_key_details_fetches_server_metrics(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test that show_key_details fetches server metrics when server_id exists."""
+        # Mock key data with server_id
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys/key-123": {
+                "id": "key-123",
+                "name": "pigpong",
+                "key_type": "wireguard",
+                "status": "active",
+                "data_used_gb": 0.0,
+                "data_limit_gb": 5.0,
+                "expires_at": "2026-05-04T00:00:00",
+                "server": "USA East 1",
+                "server_id": "server-uuid-456",
+                "last_used_at": "2026-04-04T10:00:00",
+            },
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "online",
+                "active_keys_count": 27,
+                "total_bytes_transferred": 20347013889,
+                "outline_api_reachable": True,
+            },
+        }.get(url, {})
+
+        await handler.show_key_details(mock_update, mock_context)
+
+        # Verify server metrics endpoint was called
+        calls = [call[0][0] for call in mock_api_client.get.call_args_list]
+        assert "/vpn/servers/server-uuid-456/outline" in calls
+
+    async def test_show_key_details_includes_server_metrics_in_message(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test that formatted message includes server metrics section."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys/key-123": {
+                "id": "key-123",
+                "name": "pigpong",
+                "key_type": "wireguard",
+                "status": "active",
+                "data_used_gb": 0.0,
+                "data_limit_gb": 5.0,
+                "expires_at": "2026-05-04T00:00:00",
+                "server": "USA East 1",
+                "server_id": "server-uuid-456",
+                "last_used_at": "2026-04-04T10:00:00",
+            },
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "online",
+                "active_keys_count": 27,
+                "total_bytes_transferred": 20347013889,
+                "outline_api_reachable": True,
+            },
+        }.get(url, {})
+
+        await handler.show_key_details(mock_update, mock_context)
+
+        # Verify message includes server metrics
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+
+        assert "🌐 Estado del Servidor" in message
+        assert "🟢 Online" in message
+        assert "27" in message  # active keys count
+        assert "GB" in message  # bandwidth
+
+    async def test_show_key_details_handles_missing_server_id(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test graceful handling when key has no server_id."""
+        mock_api_client.get.return_value = {
+            "id": "key-123",
+            "name": "Test Key",
+            "key_type": "outline",
+            "status": "active",
+            "data_used_gb": 1.5,
+            "data_limit_gb": 5.0,
+            "expires_at": "2026-05-04T00:00:00",
+            "server": "N/A",
+            "server_id": None,
+            "last_used_at": None,
+        }
+
+        await handler.show_key_details(mock_update, mock_context)
+
+        # Verify metrics endpoint was NOT called
+        calls = [call[0][0] for call in mock_api_client.get.call_args_list]
+        assert "/vpn/servers/" not in " ".join(calls)
+
+        # Verify message still displays with fallback
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+        assert "💎 *Test Key*" in message
+
+    async def test_show_key_details_handles_metrics_fetch_failure(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test graceful handling when metrics fetch fails."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: (
+            {
+                "/vpn/keys/key-123": {
+                    "id": "key-123",
+                    "name": "pigpong",
+                    "key_type": "wireguard",
+                    "status": "active",
+                    "data_used_gb": 0.0,
+                    "data_limit_gb": 5.0,
+                    "expires_at": "2026-05-04T00:00:00",
+                    "server": "USA East 1",
+                    "server_id": "server-uuid-456",
+                    "last_used_at": "2026-04-04T10:00:00",
+                },
+            }.get(url, {})
+            or (_ for _ in ()).throw(Exception("API Error"))
+        )
+
+        await handler.show_key_details(mock_update, mock_context)
+
+        # Verify message still displays with fallback
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+        assert "📡 Métricas no disponibles" in message or "N/A" in message
+
+    async def test_show_key_details_handles_offline_server(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test display when server is offline."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys/key-123": {
+                "id": "key-123",
+                "name": "pigpong",
+                "key_type": "wireguard",
+                "status": "active",
+                "data_used_gb": 0.0,
+                "data_limit_gb": 5.0,
+                "expires_at": "2026-05-04T00:00:00",
+                "server": "USA East 1",
+                "server_id": "server-uuid-456",
+                "last_used_at": "2026-04-04T10:00:00",
+            },
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "offline",
+                "active_keys_count": 0,
+                "total_bytes_transferred": 0,
+                "outline_api_reachable": False,
+            },
+        }.get(url, {})
+
+        await handler.show_key_details(mock_update, mock_context)
+
+        # Verify offline message
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+        assert "🔴 Offline" in message


### PR DESCRIPTION
## What

Integrate Outline server metrics into the key details view with graceful error handling.

## Changes

### Handler Updates (`src/bot/handlers/keys.py`)
- **`show_key_details()`** - Enhanced to:
  - Fetch server metrics via `_fetch_server_metrics()` when `server_id` exists
  - Format `last_seen` timestamp with `_format_last_seen()` helper
  - Display server status, active keys count, total bandwidth, and uptime
  - Graceful fallback when metrics unavailable (`📡 Métricas no disponibles`)
  - Handle offline servers (`🔴 Offline • Sin conexión`)

### Tests
- 5 integration tests covering:
  - ✅ Successful metrics fetch and display
  - ✅ Missing server_id (no metrics fetch attempted)
  - ✅ API error during metrics fetch (graceful fallback)
  - ✅ Offline server display
  - ✅ Server metrics endpoint called correctly

## Testing

- 5/5 integration tests pass
- Ruff linting: clean
- No regressions in existing tests

## Acceptance Criteria

- [x] Integration test passes
- [x] Key details message shows server metrics section
- [x] Graceful fallback when metrics unavailable
- [x] All existing tests pass
- [x] Committed to correct files