### PR TITLE
feat: enhance key list view with server status summary (#53)

### DIFF
--- a/src/bot/handlers/keys.py
+++ b/src/bot/handlers/keys.py
@@ -273,7 +273,7 @@ class KeysHandler:
                 )
 
     async def show_keys_by_type(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        """Muestra claves filtradas por tipo."""
+        """Muestra claves filtradas por tipo con estado del servidor."""
         query = update.callback_query
         if query is None or query.data is None:
             return
@@ -300,16 +300,42 @@ class KeysHandler:
                 message = KeysMessages.KEYS_LIST_HEADER.format(type=key_type.upper())
                 keyboard = KeysKeyboard.keys_list(filtered_keys, key_type)
 
-                # Add key info
+                # Add key info with improved formatting
                 for key in filtered_keys:
                     status = (
                         "🟢 Activa" if key.get("status", "active") == "active" else "🔴 Inactiva"
                     )
+                    usage = key.get("data_used_gb", 0)
+                    limit = key.get("data_limit_gb", 0)
+                    name = key.get("name", "Unknown")
+
+                    # Add warning emoji for high usage (>80%)
+                    usage_pct = (usage / limit * 100) if limit > 0 else 0
+                    warning = " ⚠️" if usage_pct > 80 else ""
+
                     message += (
-                        f"\n🔑 {key.get('name', 'Unknown')}\n"
-                        f"   📊 {key.get('data_used_gb', 0):.2f}/{key.get('data_limit_gb', 0):.2f} GB\n"
-                        f"   {status}\n"
+                        f"\n🔑 *{name}*{warning}\n   📊 {usage:.2f}/{limit:.2f} GB • {status}\n"
                     )
+
+                # Add server status summary if keys exist
+                server_id = filtered_keys[0].get("server_id")
+                if server_id:
+                    server_metrics = await self._fetch_server_metrics(
+                        server_id=server_id,
+                        telegram_id=telegram_id,
+                    )
+
+                    if server_metrics:
+                        is_online = server_metrics.get("outline_api_reachable", False)
+                        active_keys = server_metrics.get("active_keys_count", 0)
+
+                        if is_online:
+                            message += (
+                                f"\n━━━━━━━━━━━━━━━━━━━━━━\n"
+                                f"🌐 Servidor: 🟢 Online • {active_keys} keys"
+                            )
+                        else:
+                            message += "\n━━━━━━━━━━━━━━━━━━━━━━\n🌐 Servidor: 🔴 Offline"
 
             await self._safe_edit_message(query, context, message, keyboard)
 

--- a/tests/integration/test_show_keys_by_type_server_status.py
+++ b/tests/integration/test_show_keys_by_type_server_status.py
@@ -1,0 +1,187 @@
+"""Integration tests for show_keys_by_type with server status summary."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.bot.handlers.keys import KeysHandler
+
+
+class TestShowKeysByTypeWithServerStatus:
+    """Tests for show_keys_by_type handler with server status footer."""
+
+    @pytest.fixture
+    def mock_api_client(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_token_storage(self):
+        storage = AsyncMock()
+        storage.get.return_value = {"access_token": "test-token"}
+        storage.is_authenticated.return_value = True
+        return storage
+
+    @pytest.fixture
+    def handler(self, mock_api_client, mock_token_storage):
+        return KeysHandler(mock_api_client, mock_token_storage)
+
+    @pytest.fixture
+    def mock_update(self):
+        update = MagicMock()
+        update.callback_query = MagicMock()
+        update.callback_query.data = "vpn_keys_wireguard"
+        update.callback_query.answer = AsyncMock()
+        update.callback_query.edit_message_text = AsyncMock()
+        update.effective_user = MagicMock()
+        update.effective_user.id = 12345
+        return update
+
+    @pytest.fixture
+    def mock_context(self):
+        return MagicMock()
+
+    async def test_show_keys_by_type_includes_server_status_footer(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test that key list includes server status summary at bottom."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys": [
+                {
+                    "id": "key-1",
+                    "name": "pigpong",
+                    "key_type": "wireguard",
+                    "status": "active",
+                    "data_used_gb": 0.0,
+                    "data_limit_gb": 5.0,
+                    "server_id": "server-uuid-456",
+                }
+            ],
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "online",
+                "active_keys_count": 27,
+                "outline_api_reachable": True,
+            },
+        }.get(url, [])
+
+        await handler.show_keys_by_type(mock_update, mock_context)
+
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+
+        assert "🌐 Servidor:" in message
+        assert "🟢 Online" in message
+        assert "27" in message
+
+    async def test_show_keys_by_type_shows_warning_for_high_usage(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test that keys with >80% usage show ⚠️ warning emoji."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys": [
+                {
+                    "id": "key-1",
+                    "name": "Almost Full",
+                    "key_type": "wireguard",
+                    "status": "active",
+                    "data_used_gb": 4.9,
+                    "data_limit_gb": 5.0,
+                    "server_id": "server-uuid-456",
+                }
+            ],
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "online",
+                "active_keys_count": 27,
+                "outline_api_reachable": True,
+            },
+        }.get(url, [])
+
+        await handler.show_keys_by_type(mock_update, mock_context)
+
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+
+        assert "⚠️" in message
+        assert "Almost Full" in message
+
+    async def test_show_keys_by_type_handles_offline_server(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test display when server is offline."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: {
+            "/vpn/keys": [
+                {
+                    "id": "key-1",
+                    "name": "Test Key",
+                    "key_type": "wireguard",
+                    "status": "active",
+                    "data_used_gb": 1.0,
+                    "data_limit_gb": 5.0,
+                    "server_id": "server-uuid-456",
+                }
+            ],
+            "/vpn/servers/server-uuid-456/outline": {
+                "server_status": "offline",
+                "active_keys_count": 0,
+                "outline_api_reachable": False,
+            },
+        }.get(url, [])
+
+        await handler.show_keys_by_type(mock_update, mock_context)
+
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+
+        assert "🔴 Offline" in message
+
+    async def test_show_keys_by_type_handles_metrics_fetch_failure(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test graceful handling when metrics fetch fails."""
+        mock_api_client.get.side_effect = lambda url, **kwargs: (
+            {
+                "/vpn/keys": [
+                    {
+                        "id": "key-1",
+                        "name": "Test Key",
+                        "key_type": "wireguard",
+                        "status": "active",
+                        "data_used_gb": 1.0,
+                        "data_limit_gb": 5.0,
+                        "server_id": "server-uuid-456",
+                    }
+                ],
+            }.get(url, {})
+            or (_ for _ in ()).throw(Exception("API Error"))
+        )
+
+        await handler.show_keys_by_type(mock_update, mock_context)
+
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+
+        # Message should still display keys without server footer
+        assert "🔑 *Test Key*" in message
+
+    async def test_show_keys_by_type_no_server_id_skips_metrics(
+        self, handler, mock_update, mock_context, mock_api_client
+    ):
+        """Test that keys without server_id skip metrics fetch."""
+        mock_api_client.get.return_value = [
+            {
+                "id": "key-1",
+                "name": "Test Key",
+                "key_type": "wireguard",
+                "status": "active",
+                "data_used_gb": 1.0,
+                "data_limit_gb": 5.0,
+                "server_id": None,
+            }
+        ]
+
+        await handler.show_keys_by_type(mock_update, mock_context)
+
+        calls = [call[0][0] for call in mock_api_client.get.call_args_list]
+        assert "/vpn/servers/" not in " ".join(calls)
+
+        call_args = mock_update.callback_query.edit_message_text.call_args
+        message = call_args.kwargs.get("text", "")
+        assert "🔑 *Test Key*" in message


### PR DESCRIPTION
## What

Enhance key list view with server status summary footer and high-usage warning indicators.

## Changes

### Handler Updates (`src/bot/handlers/keys.py`)
- **`show_keys_by_type()`** - Enhanced to:
  - Add server status footer (🌐 Servidor: 🟢 Online • X keys)
  - Show warning emoji (⚠️) for keys with >80% usage
  - Fetch Outline metrics via `_fetch_server_metrics()` when `server_id` exists
  - Graceful handling when metrics unavailable or server_id missing
  - Handle offline servers (🔴 Offline)

### Tests
- 5 integration tests covering:
  - ✅ Server status footer displayed with online server
  - ✅ High usage warning emoji (>80%)
  - ✅ Offline server display
  - ✅ Metrics fetch failure (graceful fallback)
  - ✅ Missing server_id (no metrics fetch)

## Testing

- 5/5 integration tests pass
- Ruff linting: clean
- No regressions in existing tests

## Acceptance Criteria

- [x] Key list shows server status footer
- [x] High-usage keys show ⚠️ warning emoji
- [x] Graceful handling when server metrics unavailable
- [x] All tests pass
- [x] Committed to correct files