### PR TITLE
style: improve progress bar styling with block characters and percentage (#54)

### DIFF
--- a/src/bot/handlers/keys.py
+++ b/src/bot/handlers/keys.py
@@ -1255,15 +1255,25 @@ class KeysHandler:
                 KeysKeyboard.back_to_menu(),
             )
 
-    def _generate_progress_bar(self, percentage: float, width: int = 10) -> str:
-        """Genera una barra de progreso."""
-        filled = int((percentage / 100) * width)
+    def _generate_progress_bar(self, percentage: float, width: int = 20) -> str:
+        """Genera una barra de progreso con porcentaje.
+
+        Args:
+            percentage: Usage percentage (0-100+)
+            width: Bar width in characters (default 20)
+
+        Returns:
+            Formatted progress bar string like "██████████░░░░░░░░░░ 50%"
+        """
+        # Cap at 100% for bar display
+        capped_pct = min(percentage, 100)
+        filled = int(width * capped_pct / 100)
         empty = width - filled
 
         filled_char = "█"
         empty_char = "░"
 
-        return filled_char * filled + empty_char * empty
+        return filled_char * filled + empty_char * empty + f" {percentage:.0f}%"
 
 
 def get_keys_handlers(api_client: APIClient, token_storage: TokenStorage):

--- a/tests/unit/bot/handlers/test_progress_bar.py
+++ b/tests/unit/bot/handlers/test_progress_bar.py
@@ -1,0 +1,63 @@
+"""Tests for _generate_progress_bar helper method."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from src.bot.handlers.keys import KeysHandler
+
+
+class TestGenerateProgressBar:
+    """Tests for _generate_progress_bar helper."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create KeysHandler instance."""
+        api_client = AsyncMock()
+        token_storage = AsyncMock()
+        return KeysHandler(api_client, token_storage)
+
+    async def test_progress_bar_zero_percent(self, handler):
+        """Test 0% shows empty bar."""
+        result = handler._generate_progress_bar(0)
+        assert result == "░░░░░░░░░░░░░░░░░░░░ 0%"
+
+    async def test_progress_bar_full(self, handler):
+        """Test 100% shows filled bar."""
+        result = handler._generate_progress_bar(100)
+        assert result == "████████████████████ 100%"
+
+    async def test_progress_bar_half(self, handler):
+        """Test 50% shows half-filled bar."""
+        result = handler._generate_progress_bar(50)
+        assert result == "██████████░░░░░░░░░░ 50%"
+
+    async def test_progress_bar_over_100_shows_100_percent_bar(self, handler):
+        """Test >100% caps bar at 100% but shows actual percentage."""
+        result = handler._generate_progress_bar(150)
+        assert "150%" in result
+        assert result.startswith("████████████████████")  # 20 filled blocks
+
+    async def test_progress_bar_custom_width(self, handler):
+        """Test custom width parameter."""
+        result = handler._generate_progress_bar(50, width=10)
+        assert result == "█████░░░░░ 50%"
+
+    async def test_progress_bar_quarter(self, handler):
+        """Test 25% shows quarter-filled bar."""
+        result = handler._generate_progress_bar(25)
+        expected_filled = 5  # 20 * 0.25 = 5
+        expected_empty = 15
+        assert result == "█" * expected_filled + "░" * expected_empty + " 25%"
+
+    async def test_progress_bar_small_percentage(self, handler):
+        """Test small percentage rounds correctly."""
+        result = handler._generate_progress_bar(5)
+        expected_filled = 1  # 20 * 0.05 = 1
+        expected_empty = 19
+        assert result == "█" * expected_filled + "░" * expected_empty + " 5%"
+
+    async def test_progress_bar_uses_block_characters(self, handler):
+        """Test progress bar uses █ and ░ characters."""
+        result = handler._generate_progress_bar(50)
+        assert "█" in result
+        assert "░" in result


### PR DESCRIPTION
## What

Improve progress bar styling with better visibility and percentage display.

## Changes

### Progress Bar Updates (`src/bot/handlers/keys.py`)
- **`_generate_progress_bar()`** - Enhanced to:
  - Increase default width from 10 to 20 characters
  - Add percentage display at end (e.g., "██████████░░░░░░░░░░ 50%")
  - Cap bar fill at 100% but show actual percentage (>100% displays correctly)
  - Use █ (filled) and ░ (empty) block characters

### Tests
- 8 unit tests covering:
  - ✅ 0% (empty bar)
  - ✅ 50% (half-filled)
  - ✅ 100% (full bar)
  - ✅ >100% (capped bar, actual percentage shown)
  - ✅ Custom width parameter
  - ✅ 25% (quarter-filled)
  - ✅ 5% (small percentage)
  - ✅ Block character usage

## Testing

- 8/8 unit tests pass
- Ruff linting: clean
- No regressions in existing tests

## Acceptance Criteria

- [x] Progress bar uses █ (filled) and ░ (empty) characters
- [x] Bar width capped at 20 characters
- [x] Percentage displayed correctly even if >100%
- [x] Unit tests pass for edge cases
- [x] Committed to correct files