### PR TITLE
fix: shorten separator lines to 13 chars for mobile screens

### DIFF
--- a/src/bot/handlers/keys.py
+++ b/src/bot/handlers/keys.py
@@ -331,11 +331,11 @@ class KeysHandler:
 
                         if is_online:
                             message += (
-                                f"\n━━━━━━━━━━━━━━━━━━━━━━\n"
+                                f"\n━━━━━━━━━━━━━\n"
                                 f"🌐 Servidor: 🟢 Online • {active_keys} keys"
                             )
                         else:
-                            message += "\n━━━━━━━━━━━━━━━━━━━━━━\n🌐 Servidor: 🔴 Offline"
+                            message += "\n━━━━━━━━━━━━━\n🌐 Servidor: 🔴 Offline"
 
             await self._safe_edit_message(query, context, message, keyboard)
 
@@ -665,7 +665,7 @@ class KeysHandler:
             message += f"│ {load_emoji} Carga: {server.get('load_percentage', 0)}% • 📶 Online\n"
             message += "└─────────────────────────────\n\n"
 
-        message += "━━━━━━━━━━━━━━━━━━━━\n"
+        message += "━━━━━━━━━━━━━\n"
         message += "ℹ️ Los servidores se actualizan en tiempo real\n"
         message += "💡 Tip: Los servidores con 🟢 tienen mejor rendimiento"
 

--- a/src/bot/keyboards/messages_keys.py
+++ b/src/bot/keyboards/messages_keys.py
@@ -34,18 +34,18 @@ class KeysMessages:
     KEY_DETAILS = (
         "💎 *{name}*\n\n"
         "📡 {type} • 🖥️ {server}\n"
-        "━━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "━━━━━━━━━━━━━\n\n"
         "📊 Tu Consumo: {usage}/{limit}GB ({percentage}%)\n"
         "{usage_bar}\n\n"
         "{status_icon} Estado: *{status}*\n"
         "📅 Expira: {expires}\n"
         "🕐 Última vez: {last_seen}\n\n"
-        "━━━━━━━━━━━━━━━━━━━━━━\n"
+        "━━━━━━━━━━━━━\n"
         "🌐 Estado del Servidor\n"
         "{server_status_line}\n"
         "📈 {server_bandwidth} transferidos (total)\n"
         "⏱️ {server_uptime}\n"
-        "━━━━━━━━━━━━━━━━━━━━━━\n\n"
+        "━━━━━━━━━━━━━\n\n"
         "⚡ *Acciones:*"
     )
 

--- a/tests/unit/bot/keyboards/test_messages_keys_metrics.py
+++ b/tests/unit/bot/keyboards/test_messages_keys_metrics.py
@@ -37,7 +37,7 @@ class TestKeyDetailsTemplate:
 
     def test_key_details_template_has_separator_lines(self):
         """Test KEY_DETAILS has visual separator lines."""
-        assert "━━" in KeysMessages.KEY_DETAILS
+        assert "━" * 13 in KeysMessages.KEY_DETAILS
 
     def test_key_details_template_formatting(self):
         """Test KEY_DETAILS can be formatted with valid data."""


### PR DESCRIPTION
## What

Reduce separator lines from 22 to 13 characters for proper display on small mobile screens.

## Changes
- `KEY_DETAILS` template: 3 separators shortened
- `show_keys_by_type()`: server status footer separator
- `_format_server_list_message()`: server list footer

## Testing
- ✅ 45 tests passing
- ✅ Ruff clean