### PR TITLE
fix: update progress bar tests to match current implementation

### DIFF
--- a/tests/bot/test_keys_handlers.py
+++ b/tests/bot/test_keys_handlers.py
@@ -250,7 +250,8 @@ class TestKeysHandler:
 
             bar = handler._generate_progress_bar(50.0, width=10)
 
-            assert len(bar) == 10
+            # Format is "█████░░░░░ 50%" (bar + space + percentage)
+            assert "50%" in bar
             assert "█" in bar
             assert "░" in bar
 
@@ -267,7 +268,7 @@ class TestKeysHandler:
 
             bar = handler._generate_progress_bar(100.0, width=10)
 
-            assert bar == "██████████"
+            assert bar == "██████████ 100%"
 
     @pytest.mark.asyncio
     async def test_keys_handler_progress_bar_empty(self):
@@ -282,7 +283,7 @@ class TestKeysHandler:
 
             bar = handler._generate_progress_bar(0.0, width=10)
 
-            assert bar == "░░░░░░░░░░"
+            assert bar == "░░░░░░░░░░ 0%"
 
     @pytest.mark.asyncio
     async def test_get_keys_handlers_returns_list(self):


### PR DESCRIPTION
Fix 3 pre-existing test failures in test_keys_handlers.py. The _generate_progress_bar method returns 'bar + percentage' format, tests expected just bar characters.