### PR TITLE
fix: update auth test for user_id referral payload

### DIFF
--- a/src/bot/handlers/auth.py
+++ b/src/bot/handlers/auth.py
@@ -124,9 +124,7 @@ class AuthHandler:
                 )
             else:
                 error = result.get("message", "unknown")
-                logger.warning(
-                    f"Referral application failed: user_id={user_id}, error={error}"
-                )
+                logger.warning(f"Referral application failed: user_id={user_id}, error={error}")
 
         except Exception as e:
             # Non-blocking: log error but don't fail the registration

--- a/tests/unit/bot/handlers/test_auth_handlers.py
+++ b/tests/unit/bot/handlers/test_auth_handlers.py
@@ -46,10 +46,10 @@ class TestAuthHandlerWithReferral:
         assert first_call[0][0] == "/auth/telegram/auto-register"
         assert first_call[0][1]["telegram_id"] == 12345
 
-        # Verify referral endpoint was called second
+        # Verify referral endpoint was called second with user_id (UUID)
         second_call = mock_api.post.call_args_list[1]
         assert second_call[0][0] == "/referrals/apply-on-register"
-        assert second_call[0][1]["telegram_id"] == 12345
+        assert second_call[0][1]["user_id"] == "test-user-id"
         assert second_call[0][1]["referral_code"] == "ref_abc123def456"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes CI failure: test expects telegram_id but auth handler now sends user_id.