### PR TITLE
chore: update uv.lock version to 0.13.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "usipipo-telegram-bot"
-version = "0.10.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Update uv.lock version from 0.10.0 to 0.13.0 to match current release version.